### PR TITLE
Adds support for entrypoints in the entrypoints.json (fixes #6)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "license": "LGPL-3.0-or-later",
   "require": {
     "php": "^7.1",
+    "ext-json": "*",
     "contao/core-bundle": "^4.4",
     "symfony/webpack-encore-bundle": "^1.0",
     "heimrichhannot/contao-multi-column-editor-bundle": "^2.0",

--- a/src/Asset/EntrypointsJsonLookup.php
+++ b/src/Asset/EntrypointsJsonLookup.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2018 Heimrich & Hannot GmbH
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace HeimrichHannot\EncoreBundle\Asset;
+
+
+use Symfony\Component\DependencyInjection\Container;
+
+class EntrypointsJsonLookup
+{
+
+    public function mergeEntries(array $entrypointsJsons, array $entries, string $babelPolyfillEntryName = null) : array
+    {
+        foreach ($entrypointsJsons as $entrypointsJson) {
+            $entrypoints = $this->parseEntrypoints($entrypointsJson);
+
+            $entriesMap = [];
+            foreach ($entries as $entry) {
+                if (!isset($entry['name'])) {
+                    continue;
+                }
+
+                $entriesMap[$entry['name']] = true;
+            }
+
+            foreach ($entrypoints as $name=>$entrypoint) {
+                // Ignore the babel-polyfill entry
+                if ($name == $babelPolyfillEntryName) continue;
+
+                // Only add entries that not already exist in the symfony config
+                if (!isset($entriesMap[$name])) {
+                    $newEntry = [
+                        'name' => $name,
+                        'head' => false,
+                    ];
+
+                    if (isset($entrypoint['css'])) {
+                        $newEntry['requiresCss'] = true;
+                    }
+
+                    $entries[] = $newEntry;
+                }
+            }
+        }
+
+        return $entries;
+    }
+
+    public function parseEntrypoints(string $entrypointsJson) : array
+    {
+        if (!file_exists($entrypointsJson)) {
+            throw new \InvalidArgumentException(sprintf('Could not find the entrypoints.json: the file "%s" does not exist.', $entrypointsJson));
+        }
+
+        $entriesData = json_decode(file_get_contents($entrypointsJson), true);
+
+        if (null === $entriesData) {
+            throw new \InvalidArgumentException(sprintf('Could not decode the "%s" file', $entrypointsJson));
+        }
+
+        if (!isset($entriesData['entrypoints'])) {
+            throw new \InvalidArgumentException(sprintf('There is no "entrypoints" key in "%s"', $entrypointsJson));
+        }
+
+        return $entriesData['entrypoints'];
+    }
+
+}

--- a/src/Asset/EntrypointsJsonLookup.php
+++ b/src/Asset/EntrypointsJsonLookup.php
@@ -9,8 +9,6 @@
 namespace HeimrichHannot\EncoreBundle\Asset;
 
 
-use Symfony\Component\DependencyInjection\Container;
-
 class EntrypointsJsonLookup
 {
 
@@ -30,7 +28,7 @@ class EntrypointsJsonLookup
 
             foreach ($entrypoints as $name=>$entrypoint) {
                 // Ignore the babel-polyfill entry
-                if ($name == $babelPolyfillEntryName) continue;
+                if ($babelPolyfillEntryName !== null && $name == $babelPolyfillEntryName) continue;
 
                 // Only add entries that not already exist in the symfony config
                 if (!isset($entriesMap[$name])) {

--- a/src/Choice/EntryChoice.php
+++ b/src/Choice/EntryChoice.php
@@ -45,10 +45,12 @@ class EntryChoice extends AbstractChoice
             }
 
             $dc = $this->getContext();
+            $isBabelPolyfillAdded = ($dc instanceof DataContainer && $dc->activeRecord != null && $dc->activeRecord->addEncoreBabelPolyfill);
+
             $config['encore']['entries'] = $this->entrypointsJsonLookup->mergeEntries(
                 $config['encore']['entrypointsJsons'],
                 $config['encore']['entries'],
-                $dc instanceof DataContainer && $dc->activeRecord != null ? $dc->activeRecord->encoreBabelPolyfillEntryName : null);
+                $isBabelPolyfillAdded ? $dc->activeRecord->encoreBabelPolyfillEntryName : null);
         }
 
         if (!isset($config['encore']['entries'])) {

--- a/src/Choice/EntryChoice.php
+++ b/src/Choice/EntryChoice.php
@@ -8,11 +8,25 @@
 
 namespace HeimrichHannot\EncoreBundle\Choice;
 
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\DataContainer;
 use Contao\System;
+use HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup;
 use HeimrichHannot\UtilsBundle\Choice\AbstractChoice;
 
 class EntryChoice extends AbstractChoice
 {
+    /**
+     * @var EntrypointsJsonLookup
+     */
+    private $entrypointsJsonLookup;
+
+    public function __construct(ContaoFrameworkInterface $framework, EntrypointsJsonLookup $entrypointsJsonLookup)
+    {
+        parent::__construct($framework);
+        $this->entrypointsJsonLookup = $entrypointsJsonLookup;
+    }
+
     /**
      * @return array
      */
@@ -22,12 +36,27 @@ class EntryChoice extends AbstractChoice
 
         $config = System::getContainer()->getParameter('huh.encore');
 
+        // add entries from the entrypoints.json
+        if (isset($config['encore']['entrypointsJsons']) && is_array($config['encore']['entrypointsJsons']) && !empty($config['encore']['entrypointsJsons'])) {
+            if (!isset($config['encore']['entries'])) {
+                $config['encore']['entries'] = [];
+            } else if (!is_array($config['encore']['entries'])) {
+                return $choices;
+            }
+
+            $dc = $this->getContext();
+            $config['encore']['entries'] = $this->entrypointsJsonLookup->mergeEntries(
+                $config['encore']['entrypointsJsons'],
+                $config['encore']['entries'],
+                $dc instanceof DataContainer && $dc->activeRecord != null ? $dc->activeRecord->encoreBabelPolyfillEntryName : null);
+        }
+
         if (!isset($config['encore']['entries'])) {
             return $choices;
         }
 
         foreach ($config['encore']['entries'] as $entry) {
-            $choices[$entry['name']] = $entry['name'] . ' [' . $entry['file'] . ']';
+            $choices[$entry['name']] = $entry['name'] . (isset($entry['file']) ? ' [' . $entry['file'] . ']' : '');
         }
 
         asort($choices);

--- a/src/DependencyInjection/EncoreExtension.php
+++ b/src/DependencyInjection/EncoreExtension.php
@@ -16,6 +16,8 @@ class EncoreExtension extends Extension implements PrependExtensionInterface
 {
     private $entrypointsJsons = [];
 
+    private $encoreCacheEnabled = false;
+
     public function getAlias()
     {
         return 'huh_encore';
@@ -31,11 +33,12 @@ class EncoreExtension extends Extension implements PrependExtensionInterface
 
         $processedConfigs = $this->processConfiguration(new \Symfony\WebpackEncoreBundle\DependencyInjection\Configuration(), $configs);
 
+        $this->encoreCacheEnabled = $processedConfigs['cache'];
         if ($processedConfigs['output_path'] !== false) {
             $this->entrypointsJsons[] = $processedConfigs['output_path'] . '/entrypoints.json';
         } else {
             // TODO: multiple builds are not supported yet
-            throw new \Exception('Multiple encore are currently not supported by the Contao Encore Bundle');
+            throw new \Exception('Multiple encore builds are currently not supported by the Contao Encore Bundle');
         }
     }
 
@@ -48,6 +51,7 @@ class EncoreExtension extends Extension implements PrependExtensionInterface
         $processedConfig = $this->processConfiguration($configuration, $configs);
 
         $processedConfig['encore']['entrypointsJsons'] = $this->entrypointsJsons;
+        $processedConfig['encore']['encoreCacheEnabled'] = $this->encoreCacheEnabled;
 
         $container->setParameter('huh.encore', $processedConfig);
     }

--- a/src/DependencyInjection/EncoreExtension.php
+++ b/src/DependencyInjection/EncoreExtension.php
@@ -8,16 +8,35 @@
 
 namespace HeimrichHannot\EncoreBundle\DependencyInjection;
 
-use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class EncoreExtension extends Extension
+class EncoreExtension extends Extension implements PrependExtensionInterface
 {
+    private $entrypointsJsons = [];
+
     public function getAlias()
     {
         return 'huh_encore';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        // Load current configuration of the webpack encore bundle
+        $configs = $container->getExtensionConfig('webpack_encore');
+
+        $processedConfigs = $this->processConfiguration(new \Symfony\WebpackEncoreBundle\DependencyInjection\Configuration(), $configs);
+
+        if ($processedConfigs['output_path'] !== false) {
+            $this->entrypointsJsons[] = $processedConfigs['output_path'] . '/entrypoints.json';
+        } else {
+            // TODO: multiple builds are not supported yet
+            throw new \Exception('Multiple encore are currently not supported by the Contao Encore Bundle');
+        }
     }
 
     /**
@@ -27,6 +46,8 @@ class EncoreExtension extends Extension
     {
         $configuration = new Configuration();
         $processedConfig = $this->processConfiguration($configuration, $configs);
+
+        $processedConfig['encore']['entrypointsJsons'] = $this->entrypointsJsons;
 
         $container->setParameter('huh.encore', $processedConfig);
     }

--- a/src/EventListener/HookListener.php
+++ b/src/EventListener/HookListener.php
@@ -85,10 +85,6 @@ class HookListener
         $cssEntries    = [];
         $jsHeadEntries = [];
 
-        if (!isset($config['encore']['entries']) || !is_array($config['encore']['entries']) || empty($config['encore']['entries'])) {
-            return;
-        }
-
         // add entries from the entrypoints.json
         if (isset($config['encore']['entrypointsJsons']) && is_array($config['encore']['entrypointsJsons']) && !empty($config['encore']['entrypointsJsons'])) {
             if (!isset($config['encore']['entries'])) {
@@ -102,6 +98,10 @@ class HookListener
                 $config['encore']['entries'],
                 $layout->encoreBabelPolyfillEntryName
             );
+        }
+
+        if (!isset($config['encore']['entries']) || !is_array($config['encore']['entries']) || empty($config['encore']['entries'])) {
+            return;
         }
 
         foreach ($config['encore']['entries'] as $entry) {

--- a/src/EventListener/HookListener.php
+++ b/src/EventListener/HookListener.php
@@ -13,6 +13,7 @@ use Contao\LayoutModel;
 use Contao\Model;
 use Contao\PageModel;
 use Contao\PageRegular;
+use HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Twig\Environment;
 
@@ -27,6 +28,12 @@ class HookListener
      * @var Environment
      */
     private $twig;
+
+    /**
+     * @var EntrypointsJsonLookup
+     */
+    private $entrypointsJsonLookup;
+
     /**
      * @var ContainerInterface
      */
@@ -35,12 +42,15 @@ class HookListener
     /**
      * Constructor.
      *
-     * @param ContaoFrameworkInterface $framework
+     * @param ContainerInterface $container
+     * @param Environment $twig
+     * @param EntrypointsJsonLookup $entrypointsJsonLookup
      */
-    public function __construct(ContainerInterface $container, Environment $twig)
+    public function __construct(ContainerInterface $container, Environment $twig, EntrypointsJsonLookup $entrypointsJsonLookup)
     {
         $this->framework  = $container->get('contao.framework');
         $this->twig       = $twig;
+        $this->entrypointsJsonLookup = $entrypointsJsonLookup;
         $this->container = $container;
     }
 
@@ -71,11 +81,27 @@ class HookListener
         $templateData                     = $layout->row();
 
         // active entries
-        $jsEntries  = [];
-        $cssEntries = [];
+        $jsEntries     = [];
+        $cssEntries    = [];
+        $jsHeadEntries = [];
 
         if (!isset($config['encore']['entries']) || !is_array($config['encore']['entries']) || empty($config['encore']['entries'])) {
             return;
+        }
+
+        // add entries from the entrypoints.json
+        if (isset($config['encore']['entrypointsJsons']) && is_array($config['encore']['entrypointsJsons']) && !empty($config['encore']['entrypointsJsons'])) {
+            if (!isset($config['encore']['entries'])) {
+                $config['encore']['entries'] = [];
+            } else if (!is_array($config['encore']['entries'])) {
+                return;
+            }
+
+            $config['encore']['entries'] = $this->entrypointsJsonLookup->mergeEntries(
+                $config['encore']['entrypointsJsons'],
+                $config['encore']['entries'],
+                $layout->encoreBabelPolyfillEntryName
+            );
         }
 
         foreach ($config['encore']['entries'] as $entry) {

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,9 +1,12 @@
 services:
+  HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup: ~
+
   huh.encore.choice.entry:
     class: HeimrichHannot\EncoreBundle\Choice\EntryChoice
     public: true
     arguments:
       - "@contao.framework"
+      - "@HeimrichHannot\\EncoreBundle\\Asset\\EntrypointsJsonLookup"
   huh.encore.choice.template.imports:
     class: HeimrichHannot\EncoreBundle\Choice\ImportsTemplateChoice
     public: true

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,5 +1,8 @@
 services:
-  HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup: ~
+  HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup:
+    arguments:
+      - "@service_container"
+      - "@webpack_encore.cache"
 
   huh.encore.choice.entry:
     class: HeimrichHannot\EncoreBundle\Choice\EntryChoice

--- a/tests/Asset/EntrypointsJsonLookupTest.php
+++ b/tests/Asset/EntrypointsJsonLookupTest.php
@@ -3,14 +3,50 @@
 namespace HeimrichHannot\EncoreBundle\Test\Asset;
 
 use HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class EntrypointsJsonLookupTest extends TestCase
 {
+    /**
+     * @var MockObject
+     */
+    private $container;
+
+    /**
+     * @var EntrypointsJsonLookup
+     */
+    private $lookup;
+
+    protected function setUp()
+    {
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->lookup = new EntrypointsJsonLookup($this->container, null);
+    }
+
+    protected function setUpForCaching()
+    {
+        $this->container->expects(self::once())
+            ->method('hasParameter')
+            ->with('huh.encore')
+            ->willReturn(true);
+
+        $this->container->expects(self::once())
+            ->method('getParameter')
+            ->with('huh.encore')
+            ->willReturn([
+                'encore' => [
+                    'encoreCacheEnabled' => true
+                ]
+            ]);
+    }
+
     public function testMergeEntries()
     {
-        $lookup = new EntrypointsJsonLookup();
-        $entries = $lookup->mergeEntries([], [
+        $entries = $this->lookup->mergeEntries([], [
             [
                 'name' => 'contao-project-bundle'
             ]
@@ -19,7 +55,7 @@ class EntrypointsJsonLookupTest extends TestCase
         $this->assertCount(1, $entries);
 
 
-        $entries = $lookup->mergeEntries([
+        $entries = $this->lookup->mergeEntries([
                 __DIR__ . '/../entrypoints.json',
             ], [
                 [
@@ -43,7 +79,7 @@ class EntrypointsJsonLookupTest extends TestCase
             ]
         ], $entries);
 
-        $entries = $lookup->mergeEntries([
+        $entries = $this->lookup->mergeEntries([
                 __DIR__ . '/../entrypoints.json',
             ], [
                 [
@@ -67,8 +103,7 @@ class EntrypointsJsonLookupTest extends TestCase
 
     public function testParseEntrypoints()
     {
-        $lookup = new EntrypointsJsonLookup();
-        $entrypoints = $lookup->parseEntrypoints(__DIR__ . '/../entrypoints.json');
+        $entrypoints = $this->lookup->parseEntrypoints(__DIR__ . '/../entrypoints.json');
 
         $this->assertCount(3, $entrypoints);
         $this->assertArrayHasKey('main', $entrypoints);
@@ -80,7 +115,77 @@ class EntrypointsJsonLookupTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $lookup = new EntrypointsJsonLookup();
-        $entrypoints = $lookup->parseEntrypoints(__DIR__ . '/../notexisting.json');
+        $this->lookup->parseEntrypoints(__DIR__ . '/../notexisting.json');
+    }
+
+    public function testParseEntrypointsCachedNoHit()
+    {
+        $this->setUpForCaching();
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $item = $this->createMock(CacheItemInterface::class);
+        $cache->expects(self::once())
+            ->method('getItem')
+            ->with('_default')
+            ->willReturn($item);
+
+        $item->expects(self::exactly(2))
+            ->method('isHit')
+            ->willReturn(false);
+        $item->expects(self::once())
+            ->method('set')
+            ->with(self::isType('array'))
+            ->willReturn($item);
+
+        $cache->expects(self::once())
+            ->method('save')
+            ->with($item);
+
+        $lookup = new EntrypointsJsonLookup($this->container, $cache);
+
+        $entrypoints = $lookup->parseEntrypoints(__DIR__ . '/../entrypoints.json');
+
+        $this->assertCount(3, $entrypoints);
+        $this->assertArrayHasKey('main', $entrypoints);
+        $this->assertArrayHasKey('babel-polyfill', $entrypoints);
+        $this->assertArrayHasKey('contao-project-bundle', $entrypoints);
+    }
+
+    public function testParseEntrypointsCachedWithHit()
+    {
+        $this->setUpForCaching();
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $item = $this->createMock(CacheItemInterface::class);
+        $cache->expects(self::once())
+            ->method('getItem')
+            ->with('_default')
+            ->willReturn($item);
+
+        $item->expects(self::exactly(1))
+            ->method('isHit')
+            ->willReturn(true);
+
+        $item->expects(self::once())
+            ->method('get')
+            ->willReturn([
+                'entrypoints' => [
+                    'main' => [
+                        'name' => 'main'
+                    ],
+                ]
+            ]);
+
+        $item->expects(self::never())
+            ->method('set');
+        $cache->expects(self::never())
+            ->method('save');
+
+        $lookup = new EntrypointsJsonLookup($this->container, $cache);
+
+        $entrypoints = $lookup->parseEntrypoints(__DIR__ . '/../entrypoints.json');
+
+        $this->assertCount(1, $entrypoints);
+        $this->assertArrayHasKey('main', $entrypoints);
     }
 }

--- a/tests/Asset/EntrypointsJsonLookupTest.php
+++ b/tests/Asset/EntrypointsJsonLookupTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace HeimrichHannot\EncoreBundle\Test\Asset;
+
+use HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup;
+use PHPUnit\Framework\TestCase;
+
+class EntrypointsJsonLookupTest extends TestCase
+{
+    public function testMergeEntries()
+    {
+        $lookup = new EntrypointsJsonLookup();
+        $entries = $lookup->mergeEntries([], [
+            [
+                'name' => 'contao-project-bundle'
+            ]
+        ]);
+
+        $this->assertCount(1, $entries);
+
+
+        $entries = $lookup->mergeEntries([
+                __DIR__ . '/../entrypoints.json',
+            ], [
+                [
+                    'name' => 'contao-project-bundle'
+                ]
+            ]);
+
+        $this->assertCount(3, $entries);
+        $this->assertEquals([
+            [
+                'name' => 'contao-project-bundle'
+            ],
+            [
+                'name' => 'main',
+                'head' => false,
+                'requiresCss' => true,
+            ],
+            [
+                'name' => 'babel-polyfill',
+                'head' => false,
+            ]
+        ], $entries);
+
+        $entries = $lookup->mergeEntries([
+                __DIR__ . '/../entrypoints.json',
+            ], [
+                [
+                    'name' => 'contao-project-bundle'
+                ]
+            ],
+            'babel-polyfill');
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals([
+            [
+                'name' => 'contao-project-bundle'
+            ],
+            [
+                'name' => 'main',
+                'head' => false,
+                'requiresCss' => true,
+            ]
+        ], $entries);
+    }
+
+    public function testParseEntrypoints()
+    {
+        $lookup = new EntrypointsJsonLookup();
+        $entrypoints = $lookup->parseEntrypoints(__DIR__ . '/../entrypoints.json');
+
+        $this->assertCount(3, $entrypoints);
+        $this->assertArrayHasKey('main', $entrypoints);
+        $this->assertArrayHasKey('babel-polyfill', $entrypoints);
+        $this->assertArrayHasKey('contao-project-bundle', $entrypoints);
+    }
+
+    public function testParseEntrypointsNoFile()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $lookup = new EntrypointsJsonLookup();
+        $entrypoints = $lookup->parseEntrypoints(__DIR__ . '/../notexisting.json');
+    }
+}

--- a/tests/EventListener/HookListenerTest.php
+++ b/tests/EventListener/HookListenerTest.php
@@ -16,6 +16,7 @@ use Contao\LayoutModel;
 use Contao\PageModel;
 use Contao\PageRegular;
 use Contao\TestCase\ContaoTestCase;
+use HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup;
 use HeimrichHannot\EncoreBundle\EventListener\HookListener;
 use HeimrichHannot\EncoreBundle\Test\ModelMockTrait;
 use PHPUnit\Framework\MockObject\MockBuilder;
@@ -31,7 +32,7 @@ class HookListenerTest extends ContaoTestCase
     /**
      * @return HookListener|MockObject
      */
-    public function getHookListener(ContainerBuilder $container = null, MockBuilder $mock = null, Environment $twig = null)
+    public function getHookListener(ContainerBuilder $container = null, MockBuilder $mock = null, Environment $twig = null, EntrypointsJsonLookup $entrypointsJsonLookup = null)
     {
         if (!$container) {
             $container = $this->mockContainer();
@@ -45,13 +46,18 @@ class HookListenerTest extends ContaoTestCase
             $twig = $this->createMock(Environment::class);
         }
 
+        if (!$entrypointsJsonLookup)
+        {
+            $entrypointsJsonLookup = new EntrypointsJsonLookup();
+        }
+
         if (!$mock)
         {
-            $hookListener = new HookListener($container, $twig);
+            $hookListener = new HookListener($container, $twig, $entrypointsJsonLookup);
 
         }
         else {
-            $hookListener = $mock->setConstructorArgs([$container, $twig])->getMock();
+            $hookListener = $mock->setConstructorArgs([$container, $twig, $entrypointsJsonLookup])->getMock();
         }
         return $hookListener;
     }
@@ -171,6 +177,53 @@ class HookListenerTest extends ContaoTestCase
         $this->assertSame('contao-project-bundle', $pageRegular->Template->encoreStylesheets);
         $this->assertSame('contao-project-bundle', $pageRegular->Template->encoreStylesheetsInline);
         $this->assertCount(2, $pageRegular->Template->encoreScripts);
+        $this->assertCount(1, $pageRegular->Template->encoreHeadScripts);
+    }
+
+    public function testDoAddEncoreFromEntrypointsJson()
+    {
+        $pageModel = $this->mockClassWithProperties(PageModel::class, []);
+
+        $layoutModel = $this->mockModelObject(LayoutModel::class, []);
+        $layoutModel->addEncore = "1";
+        $layoutModel->encoreBabelPolyfillEntryName = 'babel-polyfill';
+
+        $pageRegular = $this->mockModelObject(PageRegular::class, ['Template' => new \stdClass()]);
+        $container = $this->mockContainer();
+        $container->setParameter('huh.encore', [
+            'encore' => [
+                'entrypointsJsons' => [
+                    __DIR__ . '/../entrypoints.json'
+                ],
+                'entries' => [
+                    ["head" => true],
+                    ["name" => "contao-utils-bundle"],
+                    ["name" => "contao-project-bundle", "head" => false, "requiresCss" => true],
+                    ["name" => "contao-head-bundle", "head" => true, "requiresCss" => false],
+                ]
+            ]]);
+        $twig = $this->createMock(Environment::class);
+        $twig->method('render')->willReturnCallback(function ($template, $templateData)
+        {
+            switch ($template)
+            {
+                case 'default_css':
+                    return $templateData['cssEntries'];
+                case 'default_js':
+                    return $templateData['jsEntries'];
+                case 'default_head_js':
+                    return $templateData['jsHeadEntries'];
+            }
+        });
+
+        $hookListener = $this->getHookListener($container, $this->getMockBuilder(HookListener::class)->setMethods(['isEntryActive','getItemTemplateByName']), $twig);
+        $hookListener->expects($this->exactly(4))->method('isEntryActive')->willReturn(true);
+        $hookListener->expects($this->exactly(3))->method('getItemTemplateByName')->willReturnArgument(0);
+
+        $hookListener->doAddEncore($pageModel, $layoutModel, $pageRegular);
+
+        $this->assertCount(2, $pageRegular->Template->encoreStylesheets);
+        $this->assertCount(3, $pageRegular->Template->encoreScripts);
         $this->assertCount(1, $pageRegular->Template->encoreHeadScripts);
     }
 

--- a/tests/EventListener/HookListenerTest.php
+++ b/tests/EventListener/HookListenerTest.php
@@ -48,7 +48,7 @@ class HookListenerTest extends ContaoTestCase
 
         if (!$entrypointsJsonLookup)
         {
-            $entrypointsJsonLookup = new EntrypointsJsonLookup();
+            $entrypointsJsonLookup = new EntrypointsJsonLookup($container, null);
         }
 
         if (!$mock)

--- a/tests/entrypoints.json
+++ b/tests/entrypoints.json
@@ -1,0 +1,25 @@
+{
+  "entrypoints": {
+    "main": {
+      "js": [
+        "/build/runtime.2cd2a110.js",
+        "/build/main.53cd3347.js"
+      ],
+      "css": [
+        "/build/main.fddbc675.css"
+      ]
+    },
+    "babel-polyfill": {
+      "js": [
+        "/build/runtime.2cd2a110.js",
+        "/build/babel-polyfill.5cbe8eb8.js"
+      ]
+    },
+    "contao-project-bundle": {
+      "js": [
+        "/build/runtime.2cd2a110.js",
+        "/build/contao-project-bundle.d57e544a.js"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This will parse the entrypoints.json in /build/ and add the entrypoints to the ones that are configured in the Symfony configuration.

Entrypoints that are already configured will not be replaced. The bable-polyfill entrypoint will also be ignored if it is already included in the layout.

Open questions:
- The order of entrypoints is currently ignored (this is also true for master)
- Multiple builds (which can be defined in the Webpack Encore Bundle) are not supported