### PR TITLE
Add an page entrypoint cache

### DIFF
--- a/src/Choice/EntryChoice.php
+++ b/src/Choice/EntryChoice.php
@@ -8,11 +8,10 @@
 
 namespace HeimrichHannot\EncoreBundle\Choice;
 
-use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\DataContainer;
-use Contao\System;
 use HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup;
 use HeimrichHannot\UtilsBundle\Choice\AbstractChoice;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class EntryChoice extends AbstractChoice
 {
@@ -20,11 +19,16 @@ class EntryChoice extends AbstractChoice
      * @var EntrypointsJsonLookup
      */
     private $entrypointsJsonLookup;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
 
-    public function __construct(ContaoFrameworkInterface $framework, EntrypointsJsonLookup $entrypointsJsonLookup)
+    public function __construct(ContainerInterface $container, EntrypointsJsonLookup $entrypointsJsonLookup)
     {
-        parent::__construct($framework);
+        parent::__construct($container->get('contao.framework'));
         $this->entrypointsJsonLookup = $entrypointsJsonLookup;
+        $this->container = $container;
     }
 
     /**
@@ -34,7 +38,7 @@ class EntryChoice extends AbstractChoice
     {
         $choices = [];
 
-        $config = System::getContainer()->getParameter('huh.encore');
+        $config = $this->container->getParameter('huh.encore');
 
         // add entries from the entrypoints.json
         if (isset($config['encore']['entrypointsJsons']) && is_array($config['encore']['entrypointsJsons']) && !empty($config['encore']['entrypointsJsons'])) {

--- a/src/Command/PrepareCommand.php
+++ b/src/Command/PrepareCommand.php
@@ -5,6 +5,8 @@ namespace HeimrichHannot\EncoreBundle\Command;
 use Contao\CoreBundle\Command\AbstractLockedCommand;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -24,13 +26,18 @@ class PrepareCommand extends AbstractLockedCommand
      * @var PhpArrayAdapter
      */
     private $encoreCache;
+    /**
+     * @var TagAwareAdapterInterface
+     */
+    private $cache;
 
-    public function __construct(CacheItemPoolInterface $encoreCache)
+    public function __construct(CacheItemPoolInterface $encoreCache, TagAwareAdapterInterface $cache)
     {
 
         $this->encoreCache = $encoreCache;
 
         parent::__construct();
+        $this->cache = $cache;
     }
 
 
@@ -58,6 +65,7 @@ class PrepareCommand extends AbstractLockedCommand
         @unlink($resultFile);
 
         $this->encoreCache->clear();
+        $this->cache->clear();
 
         $config = $this->getContainer()->getParameter('huh.encore');
 

--- a/src/EventListener/LayoutCallbackListener.php
+++ b/src/EventListener/LayoutCallbackListener.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2019 Heimrich & Hannot GmbH
+ *
+ * @author  Thomas Körner <t.koerner@heimrich-hannot.de>
+ * @license http://www.gnu.org/licences/lgpl-3.0.html LGPL
+ */
+
+
+namespace HeimrichHannot\EncoreBundle\EventListener;
+
+
+use Contao\DataContainer;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+
+class LayoutCallbackListener
+{
+    /**
+     * @var TagAwareAdapter
+     */
+    private $cache;
+
+    public function __construct(TagAwareAdapter $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @param DataContainer $dc
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public function onSubmitCallback($dc)
+    {
+        $this->cache->invalidateTags(['layout_'.$dc->id]);
+        return;
+    }
+}

--- a/src/EventListener/PageCallbackListener.php
+++ b/src/EventListener/PageCallbackListener.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2019 Heimrich & Hannot GmbH
+ *
+ * @author  Thomas Körner <t.koerner@heimrich-hannot.de>
+ * @license http://www.gnu.org/licences/lgpl-3.0.html LGPL
+ */
+
+
+namespace HeimrichHannot\EncoreBundle\EventListener;
+
+
+use Contao\DataContainer;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+
+class PageCallbackListener
+{
+    /**
+     * @var TagAwareAdapter
+     */
+    private $cache;
+
+    public function __construct(TagAwareAdapter $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @param DataContainer $dc
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public function onSubmitCallback($dc)
+    {
+        $this->cache->deleteItem('page_'.$dc->id);
+        $this->cache->invalidateTags(['page_'.$dc->id]);
+        return;
+    }
+}

--- a/src/Resources/config/listeners.yml
+++ b/src/Resources/config/listeners.yml
@@ -8,3 +8,9 @@ services:
     autowire: false
     arguments:
       ['@service_container', '@twig', '@HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup', '@huh.encore.cache']
+
+  huh.encore.listener.callbacks.page:
+    class: HeimrichHannot\EncoreBundle\EventListener\PageCallbackListener
+
+  huh.encore.listener.callbacks.layout:
+    class: HeimrichHannot\EncoreBundle\EventListener\LayoutCallbackListener

--- a/src/Resources/config/listeners.yml
+++ b/src/Resources/config/listeners.yml
@@ -5,3 +5,6 @@ services:
 
   huh.encore.listener.hooks:
     class: HeimrichHannot\EncoreBundle\EventListener\HookListener
+    autowire: false
+    arguments:
+      ['@service_container', '@twig', '@HeimrichHannot\EncoreBundle\Asset\EntrypointsJsonLookup', '@huh.encore.cache']

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -15,3 +15,15 @@ services:
     public: true
     arguments:
       - "@contao.framework"
+
+  huh.encore.cache:
+    class: Symfony\Component\Cache\Adapter\TagAwareAdapter
+    arguments:
+      - '@huh.encore.cache.item'
+
+  huh.encore.cache.item:
+    class: Symfony\Component\Cache\Adapter\FilesystemAdapter
+    arguments:
+      - 'huh_encore.entries'
+      - 0
+      - '%kernel.cache_dir%'

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -8,7 +8,7 @@ services:
     class: HeimrichHannot\EncoreBundle\Choice\EntryChoice
     public: true
     arguments:
-      - "@contao.framework"
+      - "@service_container"
       - "@HeimrichHannot\\EncoreBundle\\Asset\\EntrypointsJsonLookup"
   huh.encore.choice.template.imports:
     class: HeimrichHannot\EncoreBundle\Choice\ImportsTemplateChoice

--- a/src/Resources/contao/dca/tl_layout.php
+++ b/src/Resources/contao/dca/tl_layout.php
@@ -10,6 +10,8 @@
 
 $dca = &$GLOBALS['TL_DCA']['tl_layout'];
 
+$dca['config']['onsubmit_callback'][] = ['huh.encore.listener.callbacks.layout','onSubmitCallback'];
+
 /**
  * Palettes
  */

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -2,6 +2,9 @@
 
 $dca = &$GLOBALS['TL_DCA']['tl_page'];
 
+
+$dca['config']['onsubmit_callback'][] = ['huh.encore.listener.callbacks.page','onSubmitCallback'];
+
 /**
  * Palettes
  */


### PR DESCRIPTION
This pull request will add an per page entrypoint cache.

Todo:
- [x] Extract the page entry generation to own method
- [x] Implement basic caching
- [x] Implement cache as service?
- [x] Invalidate cache on page save (current page and child pages)
- [x] Invalidate cache on layout save (all items with layout tag)
- [x] Invalidate cache on prepare command (complete cache)
- [ ] Add config parameter to disable cache
- [ ] Add tests

Links:
https://symfony.com/doc/3.4/components/cache/cache_invalidation.html